### PR TITLE
Add CAD viewer with dependency hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# CAD Viewer
+
+A simple Python script for viewing 3D CAD models with [Open3D](https://www.open3d.org/).
+It loads various mesh formats via Trimesh and optionally supports STEP/IGES through the
+[OCP](https://github.com/CadQuery/OCP) library.
+
+## Usage
+
+```bash
+python cad_viewer.py <path_to_model>
+```
+
+See `requirements.txt` for required dependencies.

--- a/cad_viewer.py
+++ b/cad_viewer.py
@@ -3,8 +3,19 @@ import os
 import numpy as np
 
 # 依存関係
-import open3d as o3d
-import trimesh
+try:
+    import open3d as o3d
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "open3d is required for visualization. Install it with 'pip install open3d'."
+    ) from exc
+
+try:
+    import trimesh
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "trimesh is required for mesh processing. Install it with 'pip install trimesh'."
+    ) from exc
 
 # OCP (pythonocc) は任意
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+open3d
+trimesh
+numpy
+# Optional for STEP/IGES support
+OCP


### PR DESCRIPTION
## Summary
- add a Python CAD viewer supporting many 3D mesh formats and STEP/IGES via OCP
- include helpful messages for missing Open3D/Trimesh dependencies
- document usage and required packages

## Testing
- `python -m py_compile cad_viewer.py`
- `python cad_viewer.py` *(fails: ModuleNotFoundError: No module named 'open3d')*


------
https://chatgpt.com/codex/tasks/task_e_68ae9ffa1bf8832dade16afe398abe3d