### PR TITLE
Add pluggable 3D viewer with switchable rendering backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bunny.ply
+*.png

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# CAD Viewer
+
+A simple Python utility for viewing 3D CAD models with multiple backends.
+`cad_viewer.py` uses [Open3D](https://www.open3d.org/) and can optionally load
+STEP/IGES files via the [OCP](https://github.com/CadQuery/OCP) library.  For a
+lightweight viewer that can switch between rendering libraries, see
+`multi_viewer.py`.
+
+## Usage
+
+```bash
+python cad_viewer.py <path_to_model> --material iron
+```
+
+Alternatively, the pluggable viewer lets you pick a backend:
+
+```bash
+python multi_viewer.py <path_to_model> --backend pyassimp  # or open3d
+```
+
+See `requirements.txt` for required dependencies.
+
+## Example: render Stanford Bunny
+
+`render_bunny.py` downloads the classic Stanford Bunny model and saves a rendered
+image using headless EGL-based rendering. You can choose a metal material preset:
+
+```bash
+python render_bunny.py --material aluminum  # outputs bunny.png
+```

--- a/multi_viewer.py
+++ b/multi_viewer.py
@@ -1,0 +1,77 @@
+import argparse
+
+
+class BaseRenderer:
+    def load(self, path: str) -> None:
+        raise NotImplementedError
+
+    def render(self) -> None:
+        raise NotImplementedError
+
+
+class Open3DRenderer(BaseRenderer):
+    def __init__(self) -> None:
+        import open3d as o3d
+
+        self.o3d = o3d
+        self.mesh = None
+
+    def load(self, path: str) -> None:
+        self.mesh = self.o3d.io.read_triangle_mesh(path)
+        if self.mesh is None or self.mesh.is_empty():
+            raise RuntimeError(f"Failed to load mesh: {path}")
+        self.mesh.compute_vertex_normals()
+
+    def render(self) -> None:
+        self.o3d.visualization.draw_geometries([self.mesh])
+
+
+class PyAssimpRenderer(BaseRenderer):
+    def __init__(self) -> None:
+        import pyassimp
+        import trimesh
+        import pyrender
+
+        self.pyassimp = pyassimp
+        self.trimesh = trimesh
+        self.pyrender = pyrender
+        self.meshes = []
+
+    def load(self, path: str) -> None:
+        scene = self.pyassimp.load(path)
+        for m in scene.meshes:
+            tm = self.trimesh.Trimesh(vertices=m.vertices, faces=m.faces)
+            self.meshes.append(tm)
+        self.pyassimp.release(scene)
+
+    def render(self) -> None:
+        scene = self.pyrender.Scene()
+        for mesh in self.meshes:
+            scene.add(self.pyrender.Mesh.from_trimesh(mesh))
+        self.pyrender.Viewer(scene)
+
+
+RENDERERS = {
+    "open3d": Open3DRenderer,
+    "pyassimp": PyAssimpRenderer,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple pluggable 3D viewer")
+    parser.add_argument("path", help="Path to a 3D model file")
+    parser.add_argument(
+        "--backend",
+        choices=RENDERERS.keys(),
+        default="open3d",
+        help="Rendering backend to use",
+    )
+    args = parser.parse_args()
+
+    renderer = RENDERERS[args.backend]()
+    renderer.load(args.path)
+    renderer.render()
+
+
+if __name__ == "__main__":
+    main()

--- a/render_bunny.py
+++ b/render_bunny.py
@@ -1,0 +1,65 @@
+import os
+import argparse
+import urllib.request
+import numpy as np
+import trimesh
+import pyrender
+import imageio.v2 as iio
+
+# Use OSMesa for headless rendering
+os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+
+BUNNY_URL = "https://github.com/isl-org/open3d_downloads/releases/download/20220201-data/BunnyMesh.ply"
+BUNNY_FILE = "bunny.ply"
+
+# Simple PBR material presets for metals
+MATERIALS = {
+    "iron": {
+        "baseColorFactor": [0.56, 0.57, 0.58, 1.0],
+        "metallicFactor": 1.0,
+        "roughnessFactor": 0.5,
+    },
+    "aluminum": {
+        "baseColorFactor": [0.91, 0.92, 0.93, 1.0],
+        "metallicFactor": 1.0,
+        "roughnessFactor": 0.2,
+    },
+    "nickel": {
+        "baseColorFactor": [0.66, 0.61, 0.53, 1.0],
+        "metallicFactor": 1.0,
+        "roughnessFactor": 0.3,
+    },
+}
+
+
+def download_bunny() -> str:
+    if not os.path.exists(BUNNY_FILE):
+        urllib.request.urlretrieve(BUNNY_URL, BUNNY_FILE)
+    return BUNNY_FILE
+
+
+def render_and_save(mesh_path: str, out_path: str, material: str) -> None:
+    mesh = trimesh.load(mesh_path, force='mesh')
+    scene = pyrender.Scene()
+    mat_cfg = MATERIALS.get(material, MATERIALS["iron"])
+    mat = pyrender.MetallicRoughnessMaterial(**mat_cfg)
+    scene.add(pyrender.Mesh.from_trimesh(mesh, smooth=True, material=mat))
+    light = pyrender.DirectionalLight(color=np.ones(3), intensity=3.0)
+    scene.add(light, pose=np.eye(4))
+    camera = pyrender.PerspectiveCamera(yfov=np.pi / 3.0)
+    scene.add(camera, pose=np.array([[1,0,0,0],[0,1,0,-1],[0,0,1,1.5],[0,0,0,1]]))
+    renderer = pyrender.OffscreenRenderer(800, 600)
+    color, _ = renderer.render(scene)
+    iio.imwrite(out_path, color)
+    renderer.delete()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Render the Stanford Bunny with a metal material")
+    parser.add_argument("--material", choices=MATERIALS.keys(), default="iron", help="Material preset")
+    parser.add_argument("--out", default="bunny.png", help="Output image path")
+    args = parser.parse_args()
+
+    path = download_bunny()
+    render_and_save(path, args.out, args.material)
+    print(f"Saved {args.out} with {args.material} material")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+open3d
+trimesh
+numpy
+pyrender
+imageio
+# Backend switching
+pyassimp
+# Optional for STEP/IGES support
+OCP


### PR DESCRIPTION
## Summary
- add `multi_viewer.py` demonstrating a pluggable renderer interface for Open3D and PyAssimp
- document backend selection and new viewer usage in README
- include `pyassimp` in requirements for optional backend switching

## Testing
- `python -m py_compile cad_viewer.py render_bunny.py multi_viewer.py`
- `python multi_viewer.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68ae9ffa1bf8832dade16afe398abe3d